### PR TITLE
Add data feed starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Hackathon Dream Team Quickstart
+1. Run `yarn install`
+2. Run `yarn start`
+3. Navivate to `http://localhost:3000/datafeed`. This page automatically queries the
+production data from https://api.thegraph.com/subgraphs/name/dkirsche/asset-price-history. You
+can easily replace this with your local subgraph if you have it.
+
+
 # 🏗 scaffold-eth
 
 > is everything you need to get started building decentralized applications powered by Ethereum

--- a/README.md
+++ b/README.md
@@ -602,6 +602,16 @@ Poll your holders! Build an example emoji voting system with 🏗 <b>scaffold-et
 
 [ 🎥 here is another Graph speed run tutorial video ](https://youtu.be/T5ylzOTkn-Q)
 
+### Instructions
+Instead, you can use The Graph with 🏗 scaffold-eth (learn more):
+🚮Clean up previous data: rm -rf docker/graph-node/data/
+📡Spin up a local graph node by running yarn graph-run-node (requires Docker)
+📝Create your local subgraph by running yarn graph-create-local(only required once!)
+🚢Deploy your local subgraph by running yarn graph-ship-local
+🖍️Edit your local subgraph inpackages/subgraph/src(learn more about subgraph definition here)
+🤩Deploy your contracts and your subgraph in one go by runningyarn deploy-and-graph
+
+
 
 ---
 

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -12,7 +12,7 @@ import { Header, Account, Faucet, Ramp, Contract, GasGauge, ThemeSwitch } from "
 import { Transactor } from "./helpers";
 import { formatEther, parseEther } from "@ethersproject/units";
 //import Hints from "./Hints";
-import { Hints, ExampleUI, Subgraph } from "./views"
+import { Hints, ExampleUI, Subgraph, DataFeed } from "./views"
 import { useThemeSwitcher } from "react-css-theme-switcher";
 import { INFURA_ID, DAI_ADDRESS, DAI_ABI, NETWORK, NETWORKS } from "./constants";
 /*
@@ -123,7 +123,7 @@ function App(props) {
 
   //
   // ☝️ These effects will log your major set up and upcoming transferEvents- and balance changes
-  // 
+  //
   useEffect(()=>{
     if(DEBUG && mainnetProvider && address && selectedChainId && yourLocalBalance && yourMainnetBalance && readContracts && writeContracts && mainnetDAIContract){
       console.log("_____________________________________")
@@ -260,6 +260,10 @@ function App(props) {
           <Menu.Item key="/subgraph">
             <Link onClick={()=>{setRoute("/subgraph")}} to="/subgraph">Subgraph</Link>
           </Menu.Item>
+
+          <Menu.Item key="/datafeed">
+            <Link onClick={()=>{setRoute("/datafeed")}} to="/datafeed">Data Feed</Link>
+          </Menu.Item>
         </Menu>
 
         <Switch>
@@ -335,6 +339,15 @@ function App(props) {
           </Route>
           <Route path="/subgraph">
             <Subgraph
+            subgraphUri={props.subgraphUri}
+            tx={tx}
+            writeContracts={writeContracts}
+            mainnetProvider={mainnetProvider}
+            />
+          </Route>
+
+          <Route path="/datafeed">
+            <DataFeed
             subgraphUri={props.subgraphUri}
             tx={tx}
             writeContracts={writeContracts}

--- a/packages/react-app/src/views/DataFeed.jsx
+++ b/packages/react-app/src/views/DataFeed.jsx
@@ -13,7 +13,7 @@ import fetch from 'isomorphic-fetch';
 
 export default function DataFeed(props) {
   // NOTE: This will depend on where you deploy.
-  const [subgraph, setSubgraph] = useState("http://localhost:8000/subgraphs/name/dkirsche/asset-price-history");
+  const [subgraph, setSubgraph] = useState("https://api.thegraph.com/subgraphs/name/dkirsche/asset-price-history");
 
   function graphQLFetcher(graphQLParams) {
     return fetch(subgraph, {
@@ -25,11 +25,11 @@ export default function DataFeed(props) {
 
   const EXAMPLE_GRAPHQL = `
   {
-    assets(first: 25) {
+    assets(first: 10) {
       id
       name
       totalSupply
-      priceHistoryDaily {
+      priceHistoryDaily(first: 10) {
         id
         pricePerShare
         timestamp
@@ -47,7 +47,13 @@ export default function DataFeed(props) {
         </div>
 
         <p>
-          You have selected {subgraph}
+          You can use this to directly query PriceFeed subgraphs. Simply enter the subgraph URL below and it'll update
+          on change. Right now, you're querying: {subgraph}
+        </p>
+
+        <p>
+          If you have your own subgraph setup, you can use http://localhost:8000/subgraphs/name/dkirsche/asset-price-history
+          If you need help setting up a Subgraph, read the instructions here: https://github.com/dkirsche/token-history-subgraph/blob/main/README.md
         </p>
 
         <div style={{margin:32, height:400, border:"1px solid #888888", textAlign:'left'}}>

--- a/packages/react-app/src/views/DataFeed.jsx
+++ b/packages/react-app/src/views/DataFeed.jsx
@@ -1,0 +1,64 @@
+/* eslint-disable jsx-a11y/accessible-emoji */
+
+import React, { useState } from "react";
+import "antd/dist/antd.css";
+import { Button, Typography, Table, Input } from "antd";
+import { useQuery, gql } from '@apollo/client';
+import { Address } from "../components";
+import GraphiQL from 'graphiql';
+import 'graphiql/graphiql.min.css';
+import fetch from 'isomorphic-fetch';
+
+  const highlight = { marginLeft: 4, marginRight: 8, /*backgroundColor: "#f9f9f9",*/ padding: 4, borderRadius: 4, fontWeight: "bolder" }
+
+export default function DataFeed(props) {
+  // NOTE: This will depend on where you deploy.
+  const [subgraph, setSubgraph] = useState("http://localhost:8000/subgraphs/name/dkirsche/asset-price-history");
+
+  function graphQLFetcher(graphQLParams) {
+    return fetch(subgraph, {
+      method: 'post',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(graphQLParams),
+    }).then(response => response.json());
+  }
+
+  const EXAMPLE_GRAPHQL = `
+  {
+    assets(first: 25) {
+      id
+      name
+      totalSupply
+      priceHistoryDaily {
+        id
+        pricePerShare
+        timestamp
+        txnHash
+      }
+    }
+  }
+  `
+  return (
+    <>
+      <div style={{width:1200, margin: "auto", paddingBottom:64}}>
+
+        <div style={{margin:32, textAlign:'right'}}>
+          <Input onChange={(e)=>{setSubgraph(e.target.value)}} value={subgraph} placeholder="Enter URL of subgraph here" />
+        </div>
+
+        <p>
+          You have selected {subgraph}
+        </p>
+
+        <div style={{margin:32, height:400, border:"1px solid #888888", textAlign:'left'}}>
+          <GraphiQL fetcher={graphQLFetcher} docExplorerOpen={true} query={EXAMPLE_GRAPHQL}/>
+        </div>
+
+      </div>
+
+      <div style={{padding:64}}>
+      ...
+      </div>
+    </>
+  );
+}

--- a/packages/react-app/src/views/index.js
+++ b/packages/react-app/src/views/index.js
@@ -1,3 +1,4 @@
 export { default as Hints } from "./Hints";
 export { default as ExampleUI } from "./ExampleUI";
 export { default as Subgraph } from "./Subgraph";
+export { default as DataFeed } from "./DataFeed";


### PR DESCRIPTION
This PR builds on top of scaffold-eth and adds a new `/datafeed` endpoint that queries https://api.thegraph.com/subgraphs/name/dkirsche/asset-price-history but allows you to query local subgraphs as well. This can be used to understand the underlying data struct and start building dashboards.

![image](https://user-images.githubusercontent.com/81924824/115324182-4ace2400-a13e-11eb-9984-11143c2f15c2.png)
