### PR TITLE
Adds Curve Ren.

### DIFF
--- a/packages/react-app/src/helpers/index.js
+++ b/packages/react-app/src/helpers/index.js
@@ -4,17 +4,8 @@ export function convertToPrice(numberInWei) {
   return numberInWei / Math.pow(10, 18);
 }
 
-export function calculateAPR({reward, pricePerShare, pricePerShare_yesterday, assetPrice}) {
-  const baseAPR = ((pricePerShare - pricePerShare_yesterday) / pricePerShare_yesterday) * 365;
-  const rewardAPR = reward/pricePerShare * assetPrice * 365
-  const totalAPR = baseAPR + rewardAPR
-  //console.log({reward, pricePerShare, pricePerShare_yesterday, assetPrice, baseAPR, rewardAPR, totalAPR})
-  return totalAPR * 100;
-}
-
 export function calculateRewardOtherAPR({rewardIntegral, rewardIntegral_yesterday, rewardIntegralTimeStamp, rewardIntegralTimeStamp_yesterday, rewardPrice}) {
   if (!rewardIntegral || !rewardIntegral_yesterday || !rewardIntegralTimeStamp || !rewardIntegralTimeStamp_yesterday || !rewardPrice){
-    console.log ("returning 0")
     return 0;
   }
   const rewardDiff = (rewardIntegral - rewardIntegral_yesterday) / Math.pow(10, 18)

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -41,6 +41,9 @@ export function calculateAPR({ crvPrices, maticPrices, priceHistory, rewardHisto
     const correspondingReward = rewardHistory.find(reward => {
       return price.timestamp === reward.timestamp
     });
+
+    console.log("correspondingReward = ", correspondingReward)
+
     const correspondingRewardOther_yesterday = rewardOther.find(reward => {
       return (price.timestamp - (24*60*60)) == reward.timestamp
     });
@@ -110,13 +113,15 @@ export function calculateBaseAPR({pricePerShare, pricePerShare_yesterday}) {
 
 export function calculateCrvAPR({reward, pricePerShare, assetPrice}) {
   const rewardAPR = reward/pricePerShare * assetPrice * 365
+  console.log("reward = ", reward)
+  console.log("pricePerShare = ", pricePerShare)
+  console.log("rewardAPR  ", rewardAPR)
   //console.log({reward, pricePerShare, pricePerShare_yesterday, assetPrice, baseAPR, rewardAPR, totalAPR})
   return rewardAPR * 100;
 }
 
 export function calculateRewardOtherAPR({rewardIntegral, rewardIntegral_yesterday, rewardIntegralTimeStamp, rewardIntegralTimeStamp_yesterday, rewardPrice}) {
   if (!rewardIntegral || !rewardIntegral_yesterday || !rewardIntegralTimeStamp || !rewardIntegralTimeStamp_yesterday || !rewardPrice){
-    console.log ("returning 0")
     return 0;
   }
   const rewardDiff = (rewardIntegral - rewardIntegral_yesterday) / Math.pow(10, 18)

--- a/src/views/Dashboard.jsx
+++ b/src/views/Dashboard.jsx
@@ -117,7 +117,7 @@ export default function Dashboard(props) {
       const mainnetAssets = mainSubgraph.data.assets.map(ass => {
         return {...ass, network: 'ethereum'}
       }).filter(ass => {
-        return ass.name !== 'yearn Curve.fi yDAI/yUSDC/yUSDT/yTUSD' && ass.name !== 'curve_ren'
+        return ass.name !== 'yearn Curve.fi yDAI/yUSDC/yUSDT/yTUSD' //&& ass.name !== 'curve_ren'
       })
       const polygonAssets = maticSubgraph.data.assets.map(ass => {
         return {...ass, network: 'polygon'}
@@ -150,6 +150,7 @@ export default function Dashboard(props) {
           subgraph.apr      = {base: averageAPRs.base, reward: averageAPRs.reward, total: averageAPRs.total}
         }
 
+
         let latestPriceData;
         if (subgraph.network === 'ethereum') {
           let priceHistData   = Object.assign([], subgraph.priceHistoryDaily);
@@ -179,8 +180,6 @@ export default function Dashboard(props) {
   }, [mainSubgraph.data, maticSubgraph.data])
 
   const sortedTableData = useCallback(() => {
-    console.log("CHANGED TIMEFR")
-
     if (!selectedSubgraphs) {
       return [];
     }

--- a/src/views/Farm.jsx
+++ b/src/views/Farm.jsx
@@ -103,6 +103,7 @@ export default function Farm({ subgraph, crvPrices, maticPrices, timeframe, pric
 
   function prettyName() {
     const vaultName = subgraph.name.toLowerCase().split("_")[1];
+
     if (vaultName === 'compound')
       return 'Compound Pool'
     else if (vaultName === 'usdp')
@@ -124,7 +125,7 @@ export default function Farm({ subgraph, crvPrices, maticPrices, timeframe, pric
   return (
     <React.Fragment>
       <tr key={subgraph.name}>
-        <td class="text-center" style={{width: "15%"}}>
+        <td className="text-center" style={{width: "15%"}}>
           <div className="d-flex mb-2 justify-content-center">
             <div className="d-flex" style={{width: "100px"}}>
               <div className="farm-pair" style={{zIndex: 1}}>
@@ -141,7 +142,7 @@ export default function Farm({ subgraph, crvPrices, maticPrices, timeframe, pric
           <span className="badge bg-warning text-dark">{ subgraph.network }</span>
         </td>
 
-        <td style={{width: "15%"}} class="text-center">
+        <td style={{width: "15%"}} className="text-center">
           <h4 className="mb-1">${ commarize(subgraph.tvl) }</h4>
         </td>
 
@@ -150,8 +151,6 @@ export default function Farm({ subgraph, crvPrices, maticPrices, timeframe, pric
             <Line data={chartData} options={chartOptions()} />
           </div>
         </td>
-
-
 
         <td style={{width: "15%"}} className='text-center'>
           <h1 className="mb-1">{ totalAPR }%</h1>


### PR DESCRIPTION
Adds back Curve Ren. It looks like rewards aren't calculated correctly on Curve Ren Graph: 

## Ren Reward (incorrect)

```
reward =  1006998567637139412.463599674787222 (19 digits)
main.chunk.js:363 pricePerShare =  1016895544307564687
main.chunk.js:364 rewardAPR   819.1697358569497
```

## Normal Reward

```
reward =  48863515170943.16844237374853228444 (14 digits)
main.chunk.js:363 pricePerShare =  1077484755083754748
main.chunk.js:364 rewardAPR   0.0375141372181387
```